### PR TITLE
config.hpp requires build system to detect _WIN32_WINNT

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -144,6 +144,29 @@ if(WIN32)
         socket_recv_from_operation.cpp
     )
     list(APPEND sources ${win32Sources})
+
+    // Platform detection in CMake
+    // https://stackoverflow.com/a/40217291/6370128
+    macro(get_WIN32_WINNT version)
+        if (CMAKE_SYSTEM_VERSION)
+            set(ver ${CMAKE_SYSTEM_VERSION})
+            string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
+            string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
+            # Check for Windows 10, b/c we'll need to convert to hex 'A'.
+            if ("${verMajor}" MATCHES "10")
+                set(verMajor "A")
+                string(REGEX REPLACE "^([0-9]+)" ${verMajor} ver ${ver})
+            endif ("${verMajor}" MATCHES "10")
+            # Remove all remaining '.' characters.
+            string(REPLACE "." "" ver ${ver})
+            # Prepend each digit with a zero.
+            string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
+            set(${version} "0x${ver}")
+        endif(CMAKE_SYSTEM_VERSION)
+    endmacro(get_WIN32_WINNT)
+
+    get_WIN32_WINNT(ver)
+    add_definitions(-D_WIN32_WINNT=${ver})
 endif()
 
 add_library(cppcoro

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -148,8 +148,8 @@ if(WIN32)
     // Platform detection in CMake 
     // https://stackoverflow.com/a/40217291/6370128
     macro(get_WIN32_WINNT version)
-        if (CMAKE_SYSTEM_VERSION)
-            set(ver ${CMAKE_SYSTEM_VERSION})
+        if (CMAKE_HOST_SYSTEM_VERSION)
+            set(ver ${CMAKE_HOST_SYSTEM_VERSION})
             string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
             string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
             # Check for Windows 10, b/c we'll need to convert to hex 'A'.
@@ -162,7 +162,7 @@ if(WIN32)
             # Prepend each digit with a zero.
             string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
             set(${version} "0x${ver}")
-        endif(CMAKE_SYSTEM_VERSION)
+        endif(CMAKE_HOST_SYSTEM_VERSION)
     endmacro(get_WIN32_WINNT)
 
     get_WIN32_WINNT(ver)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -145,7 +145,7 @@ if(WIN32)
     )
     list(APPEND sources ${win32Sources})
 
-    // Platform detection in CMake
+    // Platform detection in CMake 
     // https://stackoverflow.com/a/40217291/6370128
     macro(get_WIN32_WINNT version)
         if (CMAKE_SYSTEM_VERSION)


### PR DESCRIPTION
according to comments in
https://github.com/lewissbaker/cppcoro/pull/111

The same CMAKE's _WIN32_WINNT detection is also used in Falkon

https://phabricator.kde.org/D8079